### PR TITLE
fix: swapped publisherName and publisherLogo in BlogPostJsonLd

### DIFF
--- a/src/jsonld/__tests__/__snapshots__/jsonld.test.tsx.snap
+++ b/src/jsonld/__tests__/__snapshots__/jsonld.test.tsx.snap
@@ -118,10 +118,10 @@ exports[`BlogPostJsonLd 1`] = `
   },
   "publisher": {
     "@type": "Organization",
-    "name": "",
+    "name": "Ifiok Jr.",
     "logo": {
       "@type": "ImageObject",
-      "url": ""
+      "url": "https://www.example.com/photos/logo.jpg"
     }
   },
   "description": "This is a mighty good description of this blog."

--- a/src/jsonld/__tests__/jsonld.test.tsx
+++ b/src/jsonld/__tests__/jsonld.test.tsx
@@ -101,6 +101,8 @@ test('BlogPostJsonLd', () => {
       dateModified='2015-02-05T09:00:00+08:00'
       authorName='Jane Blogs'
       description='This is a mighty good description of this blog.'
+      publisherName='Ifiok Jr.'
+      publisherLogo='https://www.example.com/photos/logo.jpg'
     />,
   );
   const jsonLD = JSON.parse(

--- a/src/jsonld/article.tsx
+++ b/src/jsonld/article.tsx
@@ -264,8 +264,8 @@ export const BlogPostJsonLd: FC<BlogPostJsonLdProps> = ({
   return (
     <ArticleJsonLd
       defer={defer}
-      publisherName={publisherLogo}
-      publisherLogo={publisherName}
+      publisherName={publisherName}
+      publisherLogo={publisherLogo}
       {...props}
       overrides={{ ...overrides, '@type': 'BlogPosting' }}
     />


### PR DESCRIPTION
## Description

The `publisherName` and `publisherLogo` fields appear to be swapped in `BlogPostJsonLd`. This PR fixes the issue.

https://github.com/ifiokjr/gatsby-plugin-next-seo/blob/a882a398933c80cd1f130d8cb6b9dc1683166d6d/src/jsonld/article.tsx#L267-L268

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/ifiokjr/gatsby-plugin-next-seo/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project and `yarn fix` runs successfully.
- [x] I have run `yarn api:generate` and updated the README documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `yarn test && yarn test:e2e`.
