### PR TITLE
Titles & Nested GatsbySeo elements

### DIFF
--- a/src/meta/base-seo.tsx
+++ b/src/meta/base-seo.tsx
@@ -1,10 +1,9 @@
 import React from 'react';
-import { Helmet } from 'react-helmet-async';
+import { Helmet, HelmetProps } from 'react-helmet-async';
 
 import { AllSeoProps, LinkProps, MetaProps } from '../types';
 
 const BASE_DEFAULTS = {
-  templateTitle: '',
   noindex: false,
   nofollow: false,
   defaultOpenGraphImageWidth: 0,
@@ -55,10 +54,6 @@ export const BaseSeo = ({
 }: AllSeoProps) => {
   const meta: MetaProps[] = [];
   const link: LinkProps[] = [];
-
-  if (props.titleTemplate) {
-    DEFAULTS.templateTitle = props.titleTemplate;
-  }
 
   const noindex =
     (props.noindex ?? DEFAULTS.noindex) ||
@@ -348,8 +343,10 @@ export const BaseSeo = ({
     if (props.openGraph.title || props.title) {
       meta.push({
         property: 'og:title',
-        content: props.openGraph.title ?? props.title,
-      }); // TODO fix titleTemplate fallback
+        content:
+          props.openGraph.title ??
+          (props.titleTemplate ?? '').replace('%s', props.title ?? ''),
+      });
     }
 
     if (props.openGraph.description || props.description) {
@@ -483,16 +480,24 @@ export const BaseSeo = ({
 
   const htmlAttributes = props.language ? { lang: props.language } : {};
 
+  const helmetProps: HelmetProps = {
+    meta,
+    link,
+    defer,
+    htmlAttributes,
+  };
+
+  if (props.title) {
+    helmetProps['title'] = props.title;
+  }
+
+  if (props.titleTemplate) {
+    helmetProps['titleTemplate'] = props.titleTemplate;
+  }
+
   return (
     <>
-      <Helmet
-        meta={meta}
-        link={link}
-        title={props.title}
-        titleTemplate={DEFAULTS.templateTitle}
-        defer={defer}
-        htmlAttributes={htmlAttributes}
-      ></Helmet>
+      <Helmet {...helmetProps}></Helmet>
     </>
   );
 };


### PR DESCRIPTION
## Description

React Helmet allows multiple `<Helmet>` instances to be used, with instances lower in the tree acting as overrides for instances higher in the tree. This PR should enable having multiple `<GatsbySeo>` elements in the same way. There was an unexpected behaviour in that the `title` set by the upper component would be set to empty if not explicitly set in the override.

This PR also adds support for `titleTemplate` to the opengraph `og:title`.

## Checklist

- [x] I have read the [**contributing**](https://github.com/ifiokjr/gatsby-plugin-next-seo/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project and `yarn fix` runs successfully.
- [x] I have run `yarn api:generate` and updated the README documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `yarn test && yarn test:e2e`.
