### PR TITLE
fix: destructure language prop from GatsbySeo and pass to BaseSeo (issue #14)

### DIFF
--- a/docs/api/gatsby-plugin-next-seo.gatsbyseo.md
+++ b/docs/api/gatsby-plugin-next-seo.gatsbyseo.md
@@ -9,7 +9,7 @@ This component render the tags in the `<head>` for SEO on a per page basis. As a
 <b>Signature:</b>
 
 ```typescript
-GatsbySeo: ({ metaTags, linkTags, canonical, description, facebook, languageAlternates, mobileAlternate, nofollow, noindex, openGraph, title, titleTemplate, twitter, }: GatsbySeoProps) => JSX.Element
+GatsbySeo: ({ metaTags, linkTags, canonical, description, facebook, language, languageAlternates, mobileAlternate, nofollow, noindex, openGraph, title, titleTemplate, twitter, }: GatsbySeoProps) => JSX.Element
 ```
 
 ## Remarks

--- a/docs/etc/gatsby-plugin-next-seo.api.md
+++ b/docs/etc/gatsby-plugin-next-seo.api.md
@@ -213,7 +213,7 @@ export interface FAQJsonLdProps extends DeferSeoProps, Overrides<FAQPage> {
 }
 
 // @public
-export const GatsbySeo: ({ metaTags, linkTags, canonical, description, facebook, languageAlternates, mobileAlternate, nofollow, noindex, openGraph, title, titleTemplate, twitter, }: GatsbySeoProps) => JSX.Element;
+export const GatsbySeo: ({ metaTags, linkTags, canonical, description, facebook, language, languageAlternates, mobileAlternate, nofollow, noindex, openGraph, title, titleTemplate, twitter, }: GatsbySeoProps) => JSX.Element;
 
 // @public (undocumented)
 export interface GatsbySeoPluginOptions extends DefaultSeoProps, BaseSeoProps {

--- a/e2e/__tests__/seo.e2e.ts
+++ b/e2e/__tests__/seo.e2e.ts
@@ -117,6 +117,11 @@ test.each(testIterator)(
     const tagAssertions: TagAssertionBuilder[] = [
       { selector: 'h1', prop: 'innerText', result: 'Overridden Seo' },
       {
+        selector: 'html',
+        prop: 'lang',
+        result: 'en',
+      },
+      {
         selector: 'head title',
         prop: 'innerText',
         result: 'Title B | Gatsby SEO',

--- a/example/src/pages/overridden.tsx
+++ b/example/src/pages/overridden.tsx
@@ -11,6 +11,7 @@ const Overridden = () => (
       title='Title B'
       description='Description B'
       canonical='https://www.canonical.ie/b'
+      language='en'
       languageAlternates={[
         {
           hrefLang: 'de-AT',

--- a/src/meta/gatsby-seo.tsx
+++ b/src/meta/gatsby-seo.tsx
@@ -29,6 +29,7 @@ export const GatsbySeo = ({
   canonical,
   description,
   facebook,
+  language,
   languageAlternates,
   mobileAlternate,
   nofollow,
@@ -45,6 +46,7 @@ export const GatsbySeo = ({
       canonical={canonical}
       description={description}
       facebook={facebook}
+      language={language}
       languageAlternates={languageAlternates}
       mobileAlternate={mobileAlternate}
       nofollow={nofollow}


### PR DESCRIPTION
## Description

Closes #14

The language attribute was implemented in BaseSeo, but BaseSeo was never sent the `language` prop from GatsbySeo so it was undefined. This fix destructures the language prop in the GatsbySeo FC, and passes it along to BaseSeo.

## Checklist
- [x] I have read the [**contributing**](https://github.com/ifiokjr/gatsby-plugin-next-seo/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project and `yarn fix` runs successfully.
- [x] I have run `yarn api:generate` and updated the README documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `yarn test && yarn test:e2e`.
