### PR TITLE
fix(jsonld): update jsonld doc remarks; add return type

### DIFF
--- a/src/jsonld/jsonld.tsx
+++ b/src/jsonld/jsonld.tsx
@@ -17,27 +17,31 @@ export interface JsonLdProps<GThing extends Thing> extends DeferSeoProps {
  * @remarks
  *
  * ```tsx
+ * import React from 'react';
+ * import { JsonLd } from 'gatsby-plugin-next-seo';
  * import { Person } from 'schema-dts';
  *
- * <JsonLd<Person>
- *   item={{
- *     "@context": "https://schema.org",
- *     "@type": "Person",
- *     name: "Grace Hopper",
- *     alternateName: "Grace Brewster Murray Hopper",
- *     alumniOf: {
- *       "@type": "CollegeOrUniversity",
- *       name: ["Yale University", "Vassar College"]
- *     },
- *     knowsAbout: ["Compilers", "Computer Science"]
- *   }}
- * />
+ * export default () => (
+ *   <JsonLd<Person>
+ *    json={{
+ *      "@context": "https://schema.org",
+ *      "@type": "Person",
+ *      name: "Grace Hopper",
+ *      alternateName: "Grace Brewster Murray Hopper",
+ *      alumniOf: {
+ *        "@type": "CollegeOrUniversity",
+ *        name: ["Yale University", "Vassar College"]
+ *      },
+ *      knowsAbout: ["Compilers", "Computer Science"]
+ *    }}
+ *  />
+ * );
  * ```
  */
 export const JsonLd = <GThing extends Thing>({
   defer,
   json,
-}: JsonLdProps<GThing>) => (
+}: JsonLdProps<GThing>): JSX.Element => (
   <Helmet defer={defer}>
     <script type='application/ld+json'>{JSON.stringify(json, null, 2)}</script>
   </Helmet>


### PR DESCRIPTION
## Description

I leveraged this plugin for a project recently and noticed the general `<JsonLd>` component's documentation referenced the wrong prop, `item` instead of the expected prop, `json`

I added the imports and some additional code to hopefully make the example more clear. An ESLint complaint about the return type missing prompted me to add `JSX.Element` to the src file as well.

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [**contributing**](https://github.com/ifiokjr/gatsby-plugin-next-seo/blob/master/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project and `yarn fix` runs successfully.
- [x] I have run `yarn api:generate` and updated the README documentation where necessary.
- [ ] New code is unit tested and all current tests pass when running `yarn test && yarn test:e2e`.
