### PR TITLE
feat: add gatsby v4 to peer deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -170,7 +170,7 @@
     "typescript": "^3.9.5"
   },
   "peerDependencies": {
-    "gatsby": "^2.0.0 || ^3.0.0",
+    "gatsby": "^2.0.0 || ^3.0.0 || ^4.0.0",
     "react-helmet-async": "^1"
   },
   "release": {


### PR DESCRIPTION
## Description
When using this package with Gatsby v4 we get an incompatibility error. However, I think this is just a matter of peerDeps. 

```
warn Plugin gatsby-plugin-next-seo is not compatible with your gatsby version 4.1.2 - It requires gatsby@^2.0.0 || ^3.0.0
```

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have read the [**contributing**](https://github.com/ifiokjr/gatsby-plugin-next-seo/blob/master/CONTRIBUTING.md) document.
- [ ] My code follows the code style of this project and `yarn fix` runs successfully.
- [ ] I have run `yarn api:generate` and updated the README documentation where necessary.
- [ ] New code is unit tested and all current tests pass when running `yarn test && yarn test:e2e`.
